### PR TITLE
Fix settings menu negative margin, incorrect menu alignment

### DIFF
--- a/config/styles.js
+++ b/config/styles.js
@@ -87,7 +87,6 @@ export default {
     },
     settingsButton: {
         alignSelf: 'center',
-
         backgroundColor: Colours.light_yellow,
         elevation: 3,
         borderRadius: 100,

--- a/config/styles.js
+++ b/config/styles.js
@@ -1,5 +1,6 @@
 import Colours from './colours'
 import { Dimensions, StyleSheet } from 'react-native'
+
 export default {
     container: {
         flex: 1,
@@ -77,34 +78,38 @@ export default {
         fontSize: 26,
         lineHeight: 35,
     },
+    settingsBox: {
+        position: 'absolute',
+        top: 60,
+        left: 0,
+        right: 0,
+        zIndex: 3,
+    },
     settingsButton: {
         alignSelf: 'center',
-        position: 'absolute',
-        textAlign: 'center',
+
+        backgroundColor: Colours.light_yellow,
+        height: 30,
+        elevation: 3,
         borderRadius: 100,
         shadowColor: 'black',
         shadowRadius: 60,
-        elevation: 3,
-        zIndex: 3,
         shadowOffset: { width: 0, height: 10 },
         shadowOpacity: 1,
-        backgroundColor: Colours.light_yellow,
-    },
-    settingsBox: {
-        top: 60,
-        alignSelf: 'center',
-        position: 'absolute',
-    },
-    touchableButton: {
-        marginHorizontal: 20,
     },
     touchableButtonLabel: {
         color: Colours.dark_yellow,
+        width: 70,
+        textAlign: "center",
     },
     menuStyle: {
         backgroundColor: Colours.dark_yellow,
         borderRadius: 25,
         marginTop: 35,
+
+        // Overrides properties in the Menu Library
+        left: 'auto', 
+        alignSelf: 'center',
     },
     menuItemStyle: {
         minWidth: 200,

--- a/config/styles.js
+++ b/config/styles.js
@@ -89,7 +89,6 @@ export default {
         alignSelf: 'center',
 
         backgroundColor: Colours.light_yellow,
-        height: 30,
         elevation: 3,
         borderRadius: 100,
         shadowColor: 'black',

--- a/screens/ScannerScreen.js
+++ b/screens/ScannerScreen.js
@@ -181,7 +181,6 @@ export default function ScannerScreen({ navigation }) {
                         About
                     </MenuItem>
                 </Menu>
-                
             </SafeAreaView>
 
             {isFocused && <ScanCamera resultHandler={handleBarCodeScanned} />}

--- a/screens/ScannerScreen.js
+++ b/screens/ScannerScreen.js
@@ -159,7 +159,6 @@ export default function ScannerScreen({ navigation }) {
                                 </Text>
                             </TouchableOpacity>
                         </View>
-                        
                     }
                     onRequestClose={hideMenu}
                     style={Styles.menuStyle}

--- a/screens/ScannerScreen.js
+++ b/screens/ScannerScreen.js
@@ -145,12 +145,12 @@ export default function ScannerScreen({ navigation }) {
                 </View>
             </Modal>
             <SafeAreaView style={Styles.settingsBox}>
-                <View style={Styles.settingsButton}>
-                    <Menu
-                        animationDuration={100}
-                        visible={menuVisible}
-                        anchor={
-                            <TouchableOpacity onPress={showMenu} style={Styles.touchableButton}>
+                <Menu
+                    animationDuration={100}
+                    visible={menuVisible}
+                    anchor={
+                        <View style={Styles.settingsButton}>
+                            <TouchableOpacity onPress={showMenu}>
                                 <Text style={Styles.touchableButtonLabel}>
                                     <MaterialIcons
                                         size={30}
@@ -158,28 +158,30 @@ export default function ScannerScreen({ navigation }) {
                                     />
                                 </Text>
                             </TouchableOpacity>
-                        }
-                        onRequestClose={hideMenu}
-                        style={Styles.menuStyle}
+                        </View>
+                        
+                    }
+                    onRequestClose={hideMenu}
+                    style={Styles.menuStyle}
+                >
+                    <MenuItem
+                        onPress={toggleVibrate}
+                        textStyle={Styles.menuItemTextStyle}
+                        style={Styles.menuItemStyle}
                     >
-                        <MenuItem
-                            onPress={toggleVibrate}
-                            textStyle={Styles.menuItemTextStyle}
-                            style={Styles.menuItemStyle}
-                        >
-                            Turn {shouldVibrate ? 'off' : 'on'} vibration
-                        </MenuItem>
+                        Turn {shouldVibrate ? 'off' : 'on'} vibration
+                    </MenuItem>
 
-                        <MenuDivider color={Colours.light_yellow} />
-                        <MenuItem
-                            onPress={showAbout}
-                            textStyle={Styles.menuItemTextStyle}
-                            style={Styles.menuItemStyle}
-                        >
-                            About
-                        </MenuItem>
-                    </Menu>
-                </View>
+                    <MenuDivider color={Colours.light_yellow} />
+                    <MenuItem
+                        onPress={showAbout}
+                        textStyle={Styles.menuItemTextStyle}
+                        style={Styles.menuItemStyle}
+                    >
+                        About
+                    </MenuItem>
+                </Menu>
+                
             </SafeAreaView>
 
             {isFocused && <ScanCamera resultHandler={handleBarCodeScanned} />}


### PR DESCRIPTION
Wasn't exactly able to reproduce the first issue on my device/emulators however should (hopefully) provide a fix, would be good to test on the device that had the problem beforehand.

- Fixes an issue where the settings menu can begin 70px to the left of the screen.
- Fixes an issue which causes the menu to be placed on the left of the settings button on wider phones.
- Tidies up the setting menu structure and styles a little bit
- Touching anywhere on the settings button will now open the menu, instead of just the centre. (This is something that's hard to do with a touch-screen and easier with a mouse, but still good to fix because it will occasionally occur)

One small issue/change is that it can cause the menu to open from the centre instead of the left which was how it was previously, but there's no way to avoid this unless we change the implementation in the menu library.